### PR TITLE
Update @atproto/api and implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@atproto/api": "^0.2.11",
+        "@atproto/api": "^0.13.16",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -23,70 +23,60 @@
       }
     },
     "node_modules/@atproto/api": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.2.11.tgz",
-      "integrity": "sha512-5JY1Ii/81Bcy1ZTGRqALsaOdc8fIJTSlMNoSptpGH73uAPQE93weDrb8sc3KoxWi1G2ss3IIBSLPJWxALocJSQ==",
+      "version": "0.13.16",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.13.16.tgz",
+      "integrity": "sha512-fWWPifh7DTiKs7v2n/trZSeqvHMQckJACbA0KjZuLksgAaQWJCO+X9rsegrAUmE2aPenvLLnK2NaPaYnj5WJBw==",
+      "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "*",
-        "@atproto/uri": "*",
-        "@atproto/xrpc": "*",
+        "@atproto/common-web": "^0.3.1",
+        "@atproto/lexicon": "^0.4.3",
+        "@atproto/syntax": "^0.3.1",
+        "@atproto/xrpc": "^0.6.4",
+        "await-lock": "^2.2.2",
+        "multiformats": "^9.9.0",
         "tlds": "^1.234.0",
-        "typed-emitter": "^2.1.0"
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.1.0.tgz",
-      "integrity": "sha512-qD6xF60hvH+cP++fk/mt+0S9cxs94KsK+rNWypNlgnlp7r9By4ltXwtDSR/DNTA8mwDeularUno4VbTd2IWIzA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.3.1.tgz",
+      "integrity": "sha512-N7wiTnus5vAr+lT//0y8m/FaHHLJ9LpGuEwkwDAeV3LCiPif4m/FS8x/QOYrx1PdZQwKso95RAPzCGWQBH5j6Q==",
+      "license": "MIT",
       "dependencies": {
-        "multiformats": "^9.6.4",
+        "graphemer": "^1.4.0",
+        "multiformats": "^9.9.0",
         "uint8arrays": "3.0.0",
-        "zod": "^3.14.2"
-      }
-    },
-    "node_modules/@atproto/identifier": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/identifier/-/identifier-0.1.0.tgz",
-      "integrity": "sha512-3LV7+4E6S0k8Rru7NBkyDF6Zf6NHVUXVS9d4l9fiXWMC49ghZMjq0vPmz80xjG1rRuFdJFbpRf4ApFciGxLIyQ==",
-      "dependencies": {
-        "@atproto/common-web": "*"
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@atproto/lexicon": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.1.0.tgz",
-      "integrity": "sha512-Iy+gV9w42xLhrZrmcbZh7VFoHjXuzWvecGHIfz44owNjjv7aE/d2P5BbOX/XicSkmQ8Qkpg0BqwYDD1XBVS+DQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.3.tgz",
+      "integrity": "sha512-lFVZXe1S1pJP0dcxvJuHP3r/a+EAIBwwU7jUK+r8iLhIja+ml6NmYv8KeFHmIJATh03spEQ9s02duDmFVdCoXg==",
+      "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "*",
-        "@atproto/identifier": "*",
-        "@atproto/nsid": "*",
-        "@atproto/uri": "*",
+        "@atproto/common-web": "^0.3.1",
+        "@atproto/syntax": "^0.3.1",
         "iso-datestring-validator": "^2.2.2",
-        "multiformats": "^9.6.4",
-        "zod": "^3.14.2"
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
       }
     },
-    "node_modules/@atproto/nsid": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@atproto/nsid/-/nsid-0.0.1.tgz",
-      "integrity": "sha512-t5M6/CzWBVYoBbIvfKDpqPj/+ZmyoK9ydZSStcTXosJ27XXwOPhz0VDUGKK2SM9G5Y7TPes8S5KTAU0UdVYFCw=="
-    },
-    "node_modules/@atproto/uri": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@atproto/uri/-/uri-0.0.2.tgz",
-      "integrity": "sha512-/6otLZF7BLpT9suSdHuXLbL12nINcWPsLmcOI+dctqovWUjH+XIRVNXDQgBYSrPVetxMiknuEwWelmnA33AEXg==",
-      "dependencies": {
-        "@atproto/identifier": "*",
-        "@atproto/nsid": "*"
-      }
+    "node_modules/@atproto/syntax": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.3.1.tgz",
+      "integrity": "sha512-fzW0Mg1QUOVCWUD3RgEsDt6d1OZ6DdFmbKcDdbzUfh0t4rhtRAC05KbZYmxuMPWDAiJ4BbbQ5dkAc/mNypMXkw==",
+      "license": "MIT"
     },
     "node_modules/@atproto/xrpc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.1.0.tgz",
-      "integrity": "sha512-LhBeZkQwPezjEtricGYnG62udFglOqlnmMSS0KyWgEAPi4KMp4H2F4jNoXcf5NPtZ9S4N4hJaErHX4PJYv2lfA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.4.tgz",
+      "integrity": "sha512-9ZAJ8nsXTqC4XFyS0E1Wlg7bAvonhXQNQ3Ocs1L1LIwFLXvsw/4fNpIHXxvXvqTCVeyHLbImOnE9UiO1c/qIYA==",
+      "license": "MIT",
       "dependencies": {
-        "@atproto/lexicon": "*",
-        "zod": "^3.14.2"
+        "@atproto/lexicon": "^0.4.3",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -530,6 +520,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1132,6 +1128,12 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1248,7 +1250,8 @@
     "node_modules/iso-datestring-validator": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
-      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA=="
+      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+      "license": "MIT"
     },
     "node_modules/js-sdsl": {
       "version": "4.4.0",
@@ -1373,7 +1376,8 @@
     "node_modules/multiformats": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -1660,21 +1664,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "optional": true
-    },
     "node_modules/semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
@@ -1847,14 +1836,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "optionalDependencies": {
-        "rxjs": "*"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -1872,6 +1853,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
       "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -2057,9 +2039,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@atproto/api": "^0.2.11",
+    "@atproto/api": "^0.13.16",
     "zod": "^3.21.4"
   }
 }

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,11 +1,10 @@
 import { bskyAccount, bskyService } from "./config.js";
 import type {
   AtpAgentLoginOpts,
-  AtpAgentOpts,
+  AtpAgentOptions,
   AppBskyFeedPost,
 } from "@atproto/api";
-import atproto from "@atproto/api";
-const { BskyAgent, RichText } = atproto;
+import { AtpAgent, RichText } from '@atproto/api';
 
 type BotOptions = {
   service: string | URL;
@@ -20,8 +19,8 @@ export default class Bot {
     dryRun: false,
   } as const;
 
-  constructor(service: AtpAgentOpts["service"]) {
-    this.#agent = new BskyAgent({ service });
+  constructor(service: AtpAgentOptions["service"]) {
+    this.#agent = new AtpAgent({ service });
   }
 
   login(loginOpts: AtpAgentLoginOpts) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ESNext" /* Specify what module code is generated. */,
+    "module": "NodeNext" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
`atproto` as default export is deprecated in API. This MR updates the dependency in `package.json` and utilizes the newer preferred implementation in `bot.ts`.